### PR TITLE
Discard internal "'" character in Relayhost comment of metadata.rb.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -54,7 +54,7 @@ attribute 'postfix/smtp_sasl_passwd',
           default: ''
 
 attribute 'postfix/relayhost_role',
-          display_name: "Postfix Relayhost's role",
+          display_name: 'Postfix Relayhost role',
           description: 'String containing the role name',
           default: 'relayhost'
 


### PR DESCRIPTION
This patch allows 'berks upload' in chefdk 3.1.0 to successfully upload on CentOS 6. It seems that the embedded single quote in the word "Relayhost's" confuses creation of the relevant metadata.json and breaks Berkshelf uploads in this environment.

It works fine with librarian-chef, just not Berkshelf.