### PR TITLE
Fix several rubocop errors.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,7 +113,6 @@ end
 # Master.cf attributes
 default['postfix']['master']['submission'] = false
 
-
 # OS Aliases
 case node['platform']
 when 'freebsd'

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -40,15 +40,15 @@ if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
 end
 
 if node['postfix']['use_alias_maps']
-   node.default['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
+  node.default['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
 end
 
 if node['postfix']['use_transport_maps']
-   node.default['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
+  node.default['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
 end
 
 if node['postfix']['use_access_maps']
-   node.default['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
+  node.default['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
 end
 
 if node['postfix']['use_virtual_aliases']

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -110,7 +110,7 @@ unless node['postfix']['smtp_generic_map_entries'].empty?
   end
 end
 
-%w{main master}.each do |cfg|
+%w( main master ).each do |cfg|
   template "#{node['postfix']['conf_dir']}/#{cfg}.cf" do
     source "#{cfg}.cf.erb"
     owner 'root'


### PR DESCRIPTION
Deleted extra blank space, used 2 spaces instead of 3, use parens
instead of curly braces