### PR TITLE
Update CAfile path for Debian-based OS.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,6 +81,8 @@ default['postfix']['main']['inet_interfaces'] = 'loopback-only'
 
 # Conditional attributes, also reference _attributes recipe
 case node['platform_family']
+when 'debian'
+  default['postfix']['cafile'] = '/etc/ssl/certs/ca-certificates.crt'
 when 'smartos'
   default['postfix']['main']['smtpd_use_tls'] = 'no'
   default['postfix']['main']['smtp_use_tls'] = 'no'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -39,7 +39,7 @@ describe 'postfix::default' do
     end
 
     it '[COOK-4423] renders file main.cf with /etc/postfix/cacert.pem' do
-      expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(%r{smtp_tls_CAfile += +/etc/postfix/cacert.pem})
+      expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(%r{smtp_tls_CAfile += +/etc/ssl/certs/ca-certificates.crt})
     end
 
     it '[COOK-4619] does not set recipient_delimiter' do


### PR DESCRIPTION
 This fixes [issue 96](https://github.com/opscode-cookbooks/postfix/issues/96). I also updated the ChefSpec test to reflect the changes.