### PR TITLE
make password file resource sensitive

### DIFF
--- a/recipes/sasl_auth.rb
+++ b/recipes/sasl_auth.rb
@@ -49,6 +49,7 @@ execute 'postmap-sasl_passwd' do
 end
 
 template node['postfix']['sasl_password_file'] do
+  sensitive true
   source 'sasl_passwd.erb'
   owner 'root'
   group node['root_group']

--- a/spec/sasl_auth_spec.rb
+++ b/spec/sasl_auth_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'postfix::sasl_auth' do
+  let(:password_file) { '/etc/postfix/sasl_passwd' }
+
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['postfix']['sasl_password_file'] = password_file
+    end.converge(described_recipe)
+  end
+
+  describe 'password file template' do
+    it 'does not display sensitive information' do
+      expect(chef_run).to create_template(password_file).with(sensitive: true)
+    end
+  end
+end


### PR DESCRIPTION
So it doesn't show on a client run when it's changed.

Is there any additional guard I need to put in here to make sure it doesn't break on versions of chef-client that don't have chef/chef#2013?