### PR TITLE
Adding Ubuntu to platform check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,7 +87,7 @@ default['postfix']['main']['inet_interfaces'] = 'loopback-only'
 
 # Conditional attributes, also reference _attributes recipe
 case node['platform_family']
-when 'debian'
+when 'debian', 'ubuntu'
   default['postfix']['cafile'] = '/etc/ssl/certs/ca-certificates.crt'
 when 'smartos'
   default['postfix']['main']['smtpd_use_tls'] = 'no'


### PR DESCRIPTION
The else case incorrectly sets the cafile under Ubuntu. This causes issues when relaying to something like Amazon SES.